### PR TITLE
feat: add Go expression_switch_statement and type_switch_statement support

### DIFF
--- a/lua/pair-lens/queries.lua
+++ b/lua/pair-lens/queries.lua
@@ -101,6 +101,8 @@ M.default_queries = {
     (if_statement) @if
     (for_statement) @for
     (select_statement) @select
+    (expression_switch_statement) @switch
+    (type_switch_statement) @switch
   ]],
 
   elm = [[


### PR DESCRIPTION
ref: https://github.com/tree-sitter/tree-sitter-go/blob/master/src/grammar.json

This change is related to `control structures`, so I didn't change the line describes Go features supported  in `README.md`.

I tested that my changes work fine locally.

<img width="372" alt=" 2025-06-10 at 0 40 09" src="https://github.com/user-attachments/assets/e32d3e24-0583-4a43-b09d-4f80bb8a00aa" />

<details><summary>Sample code</summary>
<p>

```go
func main() {
	// Sample switch statement
	day := "Monday"
	switch day {
	case "Monday":
		fmt.Println("Start of the work week.")
	case "Friday":
		fmt.Println("End of the work week.")
	case "Saturday", "Sunday":
		fmt.Println("Weekend!")
	default:
		fmt.Println("Midweek day.")
	}

	// Sample type switch statement
	var i interface{} = 42
	switch v := i.(type) {
	case int:
		fmt.Printf("Integer: %d\n", v)
	case string:
		fmt.Printf("String: %s\n", v)
	default:
		fmt.Printf("Unknown type: %T\n", v)
	}
}

```

</p>
</details> 